### PR TITLE
split data by q type according to kobo tools

### DIFF
--- a/R/map_data_to_type.R
+++ b/R/map_data_to_type.R
@@ -1,5 +1,3 @@
-
-
 #' map_data_to_type
 #' @description
 #' takes workbook list and tool and maps each column to a question type ("sm","so","num").
@@ -21,22 +19,19 @@
 #' library(targets)
 #' tar_load(iccg_clean)
 #' tar_load(tool_iccg)
-#' map_data_to_type(df_list = iccg_clean,tool = tool_iccg)
+#' map_data_to_type(df_list = iccg_clean, tool = tool_iccg)
 #' }
-
 map_data_to_type <- function(df_list,
                              tool,
-                             keep_cols=c("IN_Operation","submissionId","year")
-                             ){
-  rgx_by_type<- get_q_rgx(df_list = df_list,tool = tool)
+                             keep_cols = c("IN_Operation", "submissionId", "year")) {
+  rgx_by_type <- get_q_rgx(df_list = df_list, tool = tool)
   df_list %>%
     map(
       \(dft){
         rgx_by_type %>%
           map(\(rgx)
-              dft %>%
-                select(any_of(keep_cols),matches(rgx))
-          )
+          dft %>%
+            select(any_of(keep_cols), matches(rgx)))
       }
     )
 }
@@ -56,15 +51,17 @@ map_data_to_type <- function(df_list,
 #' @export
 #'
 #' @examples
-get_subgroup_name_rgx <- function(df_list){
+get_subgroup_name_rgx <- function(df_list) {
   # gnarly rgx modified from BARD
   put_underscore_before <- str_extract(names(df_list), "\\w{1}[a-z]")
 
-  underscore_inserted <- str_replace(string = names(df_list),
-                               pattern = put_underscore_before,
-                               replacement = paste0("_", put_underscore_before))
+  underscore_inserted <- str_replace(
+    string = names(df_list),
+    pattern = put_underscore_before,
+    replacement = paste0("_", put_underscore_before)
+  )
   underscore_inserted <- underscore_inserted[!is.na(underscore_inserted)]
-  subgroup_rgx <- paste(paste0("^",underscore_inserted),collapse = "|")
+  subgroup_rgx <- paste(paste0("^", underscore_inserted), collapse = "|")
   return(subgroup_rgx)
 }
 
@@ -80,22 +77,23 @@ get_subgroup_name_rgx <- function(df_list){
 #'
 #' @return regex pattern that can be used select columns by type from data format we have in output folder
 
-get_q_rgx <- function(df_list,tool){
+get_q_rgx <- function(df_list, tool) {
   subgroup_rm_rgx <- get_subgroup_name_rgx(df_list)
 
-  qtypes_extract <- list(so= "^select_one",
-                         sm="^select_multiple",
-                         num=c("integer|calculate"))
+  qtypes_extract <- list(
+    so = "^select_one",
+    sm = "^select_multiple",
+    num = c("integer|calculate")
+  )
   qtypes_extract %>%
     map(
       \(qtype){
         q_names <- tool$survey %>%
-          filter(str_detect(type,qtype)) %>%
+          filter(str_detect(type, qtype)) %>%
           pull(name)
-        q_name_subgroup_rm <- str_remove(string = q_names,subgroup_rm_rgx)
-        q_name_rgx <- paste(paste0("*",q_name_subgroup_rm,"*"), collapse = "|")
+        q_name_subgroup_rm <- str_remove(string = q_names, subgroup_rm_rgx)
+        q_name_rgx <- paste(paste0("*", q_name_subgroup_rm, "*"), collapse = "|")
         return(q_name_rgx)
       }
     )
 }
-

--- a/R/map_data_to_type.R
+++ b/R/map_data_to_type.R
@@ -1,0 +1,101 @@
+
+
+#' map_data_to_type
+#' @description
+#' takes workbook list and tool and maps each column to a question type ("sm","so","num").
+#' It splits each workbook into a data.frame for each question type.
+#'
+#'
+#' @param df_list workbook converted to list of data.frames
+#' @param tool kobo tool read in as list of data.frames named "survey" and "choices"
+#' @param keep_cols name of columns to keep in final data.frames regardless of qtype
+#'
+#' @return
+#' nested list:
+#'   level 1: tab name
+#'   level 2: data.frame containing columns by question type ("num","sm","so)
+#'
+#'
+#' @examples \dontrun{
+#' library(tidverse)
+#' library(targets)
+#' tar_load(iccg_clean)
+#' tar_load(tool_iccg)
+#' map_data_to_type(df_list = iccg_clean,tool = tool_iccg)
+#' }
+
+map_data_to_type <- function(df_list,
+                             tool,
+                             keep_cols=c("IN_Operation","submissionId","year")
+                             ){
+  rgx_by_type<- get_q_rgx(df_list = df_list,tool = tool)
+  df_list %>%
+    map(
+      \(dft){
+        rgx_by_type %>%
+          map(\(rgx)
+              dft %>%
+                select(any_of(keep_cols),matches(rgx))
+          )
+      }
+    )
+}
+
+#' get_subgroup_name_rgx
+#' @description
+#' Column names of sub-groups data were adjusted so that they no longer match the kobo tool. The sub-group was removed
+#' from the original column name. However, the name of tab in the workbook contains the name of sub-grou, but with the
+#' underscore removed (i.e  HCT_Org-> HCTOrg).
+#' This function just takes the name of the tab and inserts the underscore back to orignal and then creates regex which
+#' can be used in combination with `str_remove` to remove the group name from the kobo tool `name` column.
+
+#' @param df_list workbook converted to list of data.frames
+#'
+#' @return tool group/subgroup names concatenated with "^" prefix and "|" separator so that they can be targeted
+#'  string operations
+#' @export
+#'
+#' @examples
+get_subgroup_name_rgx <- function(df_list){
+  # gnarly rgx modified from BARD
+  put_underscore_before <- str_extract(names(df_list), "\\w{1}[a-z]")
+
+  underscore_inserted <- str_replace(string = names(df_list),
+                               pattern = put_underscore_before,
+                               replacement = paste0("_", put_underscore_before))
+  underscore_inserted <- underscore_inserted[!is.na(underscore_inserted)]
+  subgroup_rgx <- paste(paste0("^",underscore_inserted),collapse = "|")
+  return(subgroup_rgx)
+}
+
+
+#' get_q_rgx
+#' @description
+#' Goes through kobo survey sheet and pulls question names by type (i.e select one, select multiple, numeric). It then
+#' removes the subgroup names as they were removed in the data and concatenates them together "^" prefix and "|" separator
+#' so that they can be targeted with string operations
+#'
+#' @param df_list workbook converted to list of data.frames
+#' @param tool kobo tool read in as list of data.frames named "survey" and "choices"
+#'
+#' @return regex pattern that can be used select columns by type from data format we have in output folder
+
+get_q_rgx <- function(df_list,tool){
+  subgroup_rm_rgx <- get_subgroup_name_rgx(df_list)
+
+  qtypes_extract <- list(so= "^select_one",
+                         sm="^select_multiple",
+                         num=c("integer|calculate"))
+  qtypes_extract %>%
+    map(
+      \(qtype){
+        q_names <- tool$survey %>%
+          filter(str_detect(type,qtype)) %>%
+          pull(name)
+        q_name_subgroup_rm <- str_remove(string = q_names,subgroup_rm_rgx)
+        q_name_rgx <- paste(paste0("*",q_name_subgroup_rm,"*"), collapse = "|")
+        return(q_name_rgx)
+      }
+    )
+}
+

--- a/_targets.R
+++ b/_targets.R
@@ -70,5 +70,19 @@ list(
                            skip=0,
                            sheet_names = c("survey","choices")
                            )
+    ),
+
+# Map data to Kobo Tool Question Types ------------------------------------
+  tar_target(
+    name = iccg_by_qtype,
+    command= map_data_to_type(df_list = iccg_clean,
+                              tool = tool_iccg,
+                              keep_cols=c("IN_Operation","submissionId","year"))
+    ),
+  tar_target(
+    name = clusters_by_qtype,
+    command= map_data_to_type(df_list = clusters_clean,
+                              tool = tool_clusters,
+                              keep_cols=c("IN_Operation","submissionId","year"))
     )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -12,8 +12,8 @@ tar_source()
 
 list(
 
-# Track input files -------------------------------------------------------
-# this way if the files change targets will get re-run
+  # Track input files -------------------------------------------------------
+  # this way if the files change targets will get re-run
   tar_target(
     name = iccg_file,
     command = file.path(
@@ -34,17 +34,17 @@ list(
   ),
   tar_target(
     name = iccg_tool_file,
-    command = file.path(Sys.getenv("SWAPS_SUPPORT"),"CDM2022-HCTICCG_XLSForms_V1.0.xlsx"),
+    command = file.path(Sys.getenv("SWAPS_SUPPORT"), "CDM2022-HCTICCG_XLSForms_V1.0.xlsx"),
     format = "file"
   ),
   tar_target(
     name = cluster_tool_file,
-    command = file.path(Sys.getenv("SWAPS_SUPPORT"),"CDM2022-ClusterSector_XLSForms_V1.0.xlsx"),
+    command = file.path(Sys.getenv("SWAPS_SUPPORT"), "CDM2022-ClusterSector_XLSForms_V1.0.xlsx"),
     format = "file"
   ),
 
-# Read Data ---------------------------------------------------------------
-## Data sets to Analyze ####
+  # Read Data ---------------------------------------------------------------
+  ## Data sets to Analyze ####
   tar_target(
     name = iccg_clean,
     command = load_swaps(fp = iccg_file)
@@ -54,35 +54,41 @@ list(
     name = clusters_clean,
     command = load_swaps(fp = clusters_data_file)
   ),
-## Tools ####
+  ## Tools ####
   tar_target(
     name = tool_iccg,
-    command= read_all_tabs(fp = iccg_tool_file,
-                           clean_names = F,
-                           skip=0,
-                           sheet_names = c("survey","choices")
-                           )
-    ),
+    command = read_all_tabs(
+      fp = iccg_tool_file,
+      clean_names = F,
+      skip = 0,
+      sheet_names = c("survey", "choices")
+    )
+  ),
   tar_target(
     name = tool_clusters,
-    command= read_all_tabs(fp = cluster_tool_file,
-                           clean_names = F,
-                           skip=0,
-                           sheet_names = c("survey","choices")
-                           )
-    ),
+    command = read_all_tabs(
+      fp = cluster_tool_file,
+      clean_names = F,
+      skip = 0,
+      sheet_names = c("survey", "choices")
+    )
+  ),
 
-# Map data to Kobo Tool Question Types ------------------------------------
+  # Map data to Kobo Tool Question Types ------------------------------------
   tar_target(
     name = iccg_by_qtype,
-    command= map_data_to_type(df_list = iccg_clean,
-                              tool = tool_iccg,
-                              keep_cols=c("IN_Operation","submissionId","year"))
-    ),
+    command = map_data_to_type(
+      df_list = iccg_clean,
+      tool = tool_iccg,
+      keep_cols = c("IN_Operation", "submissionId", "year")
+    )
+  ),
   tar_target(
     name = clusters_by_qtype,
-    command= map_data_to_type(df_list = clusters_clean,
-                              tool = tool_clusters,
-                              keep_cols=c("IN_Operation","submissionId","year"))
+    command = map_data_to_type(
+      df_list = clusters_clean,
+      tool = tool_clusters,
+      keep_cols = c("IN_Operation", "submissionId", "year")
     )
+  )
 )

--- a/_targets/meta/meta
+++ b/_targets/meta/meta
@@ -1,8 +1,12 @@
 name|type|data|command|depend|seed|path|time|size|bytes|format|repository|iteration|parent|children|seconds|warnings|error
 cluster_tool_file|stem|cdcb86acc667375f|9cf4425598d63391|a532b606f052f163|415615063|/Users/zackarno/Library/CloudStorage/GoogleDrive-Zachary.arno@humdata.org/Shared drives/Predictive Analytics/SWAPS Support/2023_support/CDM2022-ClusterSector_XLSForms_V1.0.xlsx|t19502.3671364352s|c3b56309db5816e7|203354|file|local|vector|||0.001||
+clusters_by_qtype|stem|98987d10b3ea7504|070d4a2be6c5544b|577dedf847b51cea|719284658||t19524.4407806435s|105412e72442d7ce|255575|rds|local|vector|||0.144||
 clusters_clean|stem|0bdb1e59ba68d377|9c2d8c3311397cfa|1c7b8d61dff7c162|21588182||t19524.3446831116s|944ce9b583565842|562098|rds|local|vector|||0.521||
 clusters_data_file|stem|f1546871a35f024a|26dbbf47fd14c2bd|a532b606f052f163|-1304879222|/Users/zackarno/Library/CloudStorage/GoogleDrive-Zachary.arno@humdata.org/Shared drives/Predictive Analytics/SWAPS Support/2023_support/output/swaps_clusters_data.xlsx|t19516.6818460301s|b72793cd956a02d1|1971226|file|local|vector|||0||
 clusters_data_fp|object|7acfea71c43ee05b|||||||||||||||
+get_q_rgx|function|10389abbfa17fd5c|||||||||||||||
+get_subgroup_name_rgx|function|d18505f493633fe4|||||||||||||||
+iccg_by_qtype|stem|f355de9b9f8fddc7|30a37dfa5b00e21a|15ce6131da530941|-2042466529||t19524.4407772074s|7626049e23dd78ab|112538|rds|local|vector|||0.059||
 iccg_clean|stem|ba02b9de4110f2c6|1493008e4990b0cf|c3917e9f95ec51e4|-1629508772||t19524.3446861327s|ae9069317d5f6912|154272|rds|local|vector|||0.234||
 iccg_data_fp|object|df1a40afd00ada33|||||||||||||||
 iccg_file|stem|6b7984c8eedc7fa2|6f13f6fcc7cdc718|a532b606f052f163|290652339|/Users/zackarno/Library/CloudStorage/GoogleDrive-Zachary.arno@humdata.org/Shared drives/Predictive Analytics/SWAPS Support/2023_support/output/swaps_iccg_data.xlsx|t19516.6837539005s|a8ae5f6d9a515c98|331438|file|local|vector|||0||
@@ -10,6 +14,7 @@ iccg_fp|object|df1a40afd00ada33|||||||||||||||
 iccg_tool_file|stem|43306ba5cb4e80ef|5f8f90fa0753ec0e|a532b606f052f163|1730898028|/Users/zackarno/Library/CloudStorage/GoogleDrive-Zachary.arno@humdata.org/Shared drives/Predictive Analytics/SWAPS Support/2023_support/CDM2022-HCTICCG_XLSForms_V1.0.xlsx|t19524.3126359722s|87b63ac157fddb30|142306|file|local|vector|||0||
 load_iccg_wb|function|e97f8b81c7d8718c|||||||||||||||
 load_swaps|function|f8d80b7e36bdce00|||||||||||||||
+map_data_to_type|function|a1c6b6d8168103fb|||||||||||||||
 read_all_tabs|function|3eb60a299aedb402|||||||||||||||
 tool_clusters|stem|61cbb9b4c68c3e23|cf7e9b6a1f254fe4|d0b5a801696ecafc|803074268||t19524.3510088228s|ff6c64288287c900|55329|rds|local|vector|||0.064||
 tool_iccg|stem|8e40b048e6ccc78b|988614bdba32bd59|05a92d0fc99e2c71|847372695||t19524.3410162004s|6a5502aed853ab52|39073|rds|local|vector|||0.041||


### PR DESCRIPTION
split workbook data.frames by tool according to qtype in tool.

warning - contains some gnarly regex. Since sub-group q names were changed in tabs I used the tab names + regex to recreate the sub-group names and remove them from the `name` column of the `survey` sheet. I thought this would be nicer than converting the names back to there original format in our data workbooks